### PR TITLE
v0.05

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,7 @@
 		- Added imgresize hook max width/height limits, 10000
 		- Added css and js hooks
 		- Added minify hook for css and js
+		- Downloader::throw() fix for uid
 
 0.04	2017-02-23
 		- Bug fixed for path digest creating

--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@
 		- Path digest change to md5 from sha256
 		- Added hook info to cache files and Downloader::throw()
 		- Improved fastcgi params check
+		- Added imgresize hook max width/height limits, 10000
 
 0.04	2017-02-23
 		- Bug fixed for path digest creating

--- a/Changes
+++ b/Changes
@@ -3,6 +3,8 @@
 		- Added hook info to cache files and Downloader::throw()
 		- Improved fastcgi params check
 		- Added imgresize hook max width/height limits, 10000
+		- Added css and js hooks
+		- Added minify hook for css and js
 
 0.04	2017-02-23
 		- Bug fixed for path digest creating

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 0.05	2017-02-24
 		- Path digest change to md5 from sha256
 		- Added hook info to cache files and Downloader::throw()
+		- Improved fastcgi params check
 
 0.04	2017-02-23
 		- Bug fixed for path digest creating

--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+0.05	2017-02-24
+		- Path digest change to md5 from sha256
+		- Added hook info to cache files and Downloader::throw()
+
 0.04	2017-02-23
 		- Bug fixed for path digest creating
 		- Added CDNGET_URI

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -19,6 +19,8 @@ WriteMakefile(
 		'Digest::MD5'	=> '2.55',
 		'LWP::UserAgent' => '6.15',
 		'GD'			=> '2.56',
+		'CSS::Minifier::XS'	=> '0.09',
+		'JavaScript::Minifier::XS' => '0.11',
 		'Lazy::Utils'	=> '1.08',
 		'Object::Base'	=> '1.11',
 	},

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,7 +16,7 @@ WriteMakefile(
 		'Time::HiRes'	=> '1.9740',
 		'DateTime'		=> '1.42',
 		'FCGI'			=> '0.78',
-		'Digest::SHA'	=> '5.96',
+		'Digest::MD5'	=> '2.55',
 		'LWP::UserAgent' => '6.15',
 		'GD'			=> '2.56',
 		'Lazy::Utils'	=> '1.08',

--- a/README
+++ b/README
@@ -2,7 +2,7 @@ NAME
     App::cdnget - CDN Reverse Proxy
 
 VERSION
-    version 0.04
+    version 0.05
 
 ABSTRACT
     CDN Reverse Proxy

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ App::cdnget - CDN Reverse Proxy
 
 # VERSION
 
-version 0.04
+version 0.05
 
 # ABSTRACT
 

--- a/lib/App/cdnget.pm
+++ b/lib/App/cdnget.pm
@@ -18,7 +18,7 @@ p5-cdnget is a FastCGI application that flexible pull-mode Content Delivery Netw
 B<This is ALPHA version>
 
 =cut
-### TODO: css, js minifier. throw log hook, client-hook header.
+### TODO: css, js minifier.
 BEGIN
 {
 	require Config;

--- a/lib/App/cdnget.pm
+++ b/lib/App/cdnget.pm
@@ -5,7 +5,7 @@ App::cdnget - CDN Reverse Proxy
 
 =head1 VERSION
 
-version 0.04
+version 0.05
 
 =head1 ABSTRACT
 
@@ -18,6 +18,7 @@ p5-cdnget is a FastCGI application that flexible pull-mode Content Delivery Netw
 B<This is ALPHA version>
 
 =cut
+### TODO: css, js minifier. throw log hook, client-hook header.
 BEGIN
 {
 	require Config;
@@ -51,7 +52,7 @@ use App::cdnget::Downloader;
 BEGIN
 {
 	require Exporter;
-	our $VERSION     = '0.04';
+	our $VERSION     = '0.05';
 	our @ISA         = qw(Exporter);
 	our @EXPORT      = qw(main run);
 	our @EXPORT_OK   = qw();

--- a/lib/App/cdnget/Downloader.pm
+++ b/lib/App/cdnget/Downloader.pm
@@ -140,7 +140,7 @@ sub throw
 	{
 		$msg = "Unknown" unless $msg;
 		$msg = "Downloader ".
-			"uid=$self->uid ".
+			"uid=".$self->uid." ".
 			"url=\"".shellmeta($self->url)."\" ".
 			"hook=\"".shellmeta($self->hook)."\" ".
 			$msg;

--- a/lib/App/cdnget/Downloader.pm
+++ b/lib/App/cdnget/Downloader.pm
@@ -19,7 +19,7 @@ use App::cdnget::Exception;
 
 BEGIN
 {
-	our $VERSION     = '0.04';
+	our $VERSION     = '0.05';
 }
 
 
@@ -140,6 +140,7 @@ sub throw
 		$msg = "Downloader ".
 			"uid=$self->uid ".
 			"url=\"".shellmeta($self->url)."\" ".
+			"hook=\"".shellmeta($self->hook)."\" ".
 			$msg;
 	}
 	App::cdnget::Exception->throw($msg, 1);
@@ -320,6 +321,7 @@ sub run
 				if ($header)
 				{
 					$header .= "Client-URL: ".$self->url."\r\n";
+					$header .= "Client-Hook: ".$self->hook."\r\n";
 					$header .= "Client-Date: ".POSIX::strftime($App::cdnget::DTF_RFC822_GMT, gmtime)."\r\n";
 					$data = "" unless defined($data);
 					$fh->print($header."\r\n".$data) or $self->throw($!);

--- a/lib/App/cdnget/Downloader.pm
+++ b/lib/App/cdnget/Downloader.pm
@@ -171,8 +171,8 @@ sub processHook_img
 	{
 		when (/^imgresize$/i)
 		{
-			$params[0] = $img->width unless defined($params[0]) and $params[0] > 0;
-			$params[1] = $img->height unless defined($params[1]) and $params[1] > 0;
+			$params[0] = $img->width unless defined($params[0]) and $params[0] > 0 and $params[0] <= 10000;
+			$params[1] = $img->height unless defined($params[1]) and $params[1] > 0 and $params[1] <= 10000;
 			$params[2] = 60 unless defined($params[2]) and $params[2] >= 0 and $params[2] <= 100;
 			my $newimg = new GD::Image($params[0], $params[1]) or $self->throw($!);
 			$newimg->copyResampled($img, 0, 0, 0, 0, $params[0], $params[1], $img->width, $img->height);

--- a/lib/App/cdnget/Worker.pm
+++ b/lib/App/cdnget/Worker.pm
@@ -164,20 +164,29 @@ sub worker
 	my $env = $req->GetEnvironment();
 
 	my $id = $env->{CDNGET_ID};
-	$self->throw("Invalid ID") unless defined($id) and $id =~ /^\w+$/i;
+	$self->throw("Invalid ID") unless defined($id);
+	$id = ($id =~ /^(.*)/)[0];
+	$id =~ s/^\s+|\s+$//g;
+	$self->throw("Invalid ID") unless $id =~ /^\w+$/i;
 
 	my $origin = $env->{CDNGET_ORIGIN};
 	$self->throw("Invalid origin") unless defined($origin);
+	$origin = ($origin =~ /^(.*)/)[0];
+	$origin =~ s/^\s+|\s+$//g;
 	$origin = URI->new($origin);
 	$self->throw("Invalid origin scheme") unless $origin->scheme =~ /^http|https$/i;
 	$origin->path(substr($origin->path, 0, length($origin->path)-1)) while $origin->path and substr($origin->path, -1) eq "/";
 
 	my $uri = $env->{CDNGET_URI};
 	$self->throw("Invalid URI") unless defined($uri);
+	$uri = ($uri =~ /^(.*)/)[0];
+	$uri =~ s/^\s+|\s+$//g;
 	$uri = "/$uri" unless $uri and substr($uri, 0, 1) eq "/";
 
 	my $hook = $env->{CDNGET_HOOK};
 	$hook = "" unless defined($hook);
+	$hook = ($hook =~ /^(.*)/)[0];
+	$hook =~ s/^\s+|\s+$//g;
 
 	my $url = $origin->scheme."://".$origin->host_port.$origin->path.$uri;
 	my $digest = Digest::MD5::md5_hex("$url $hook");

--- a/lib/App/cdnget/Worker.pm
+++ b/lib/App/cdnget/Worker.pm
@@ -7,7 +7,7 @@ use FileHandle;
 use Time::HiRes qw(sleep usleep);
 use Thread::Semaphore;
 use FCGI;
-use Digest::SHA;
+use Digest::MD5;
 
 use App::cdnget;
 use App::cdnget::Exception;
@@ -16,7 +16,7 @@ use App::cdnget::Downloader;
 
 BEGIN
 {
-	our $VERSION     = '0.04';
+	our $VERSION     = '0.05';
 }
 
 
@@ -180,13 +180,13 @@ sub worker
 	$hook = "" unless defined($hook);
 
 	my $url = $origin->scheme."://".$origin->host_port.$origin->path.$uri;
-	my $digest = Digest::SHA::sha256_hex("$url $hook");
+	my $digest = Digest::MD5::md5_hex("$url $hook");
 	my $uid = "$id/$digest";
 	my $path = "$cachePath/$id";
 	mkdir($path);
-	my @dirs = $digest =~ /..../g;
-	my $file = pop @dirs;
-	for (@dirs)
+	my @dirs = $digest =~ /(..)(.)$/;
+	my $file = $digest;
+	for (reverse @dirs)
 	{
 		$path .= "/$_";
 		mkdir($path);


### PR DESCRIPTION
- Path digest change to md5 from sha256
- Added hook info to cache files and Downloader::throw()
- Improved fastcgi params check
- Added imgresize hook max width/height limits, 10000
- Added css and js hooks
- Added minify hook for css and js
- Downloader::throw() fix for uid